### PR TITLE
Progressive enhancement for preloader screen

### DIFF
--- a/_includes/landing.html
+++ b/_includes/landing.html
@@ -1,10 +1,5 @@
 <div class="ns-landing-screen">
-    <div class="preloader">
-        <div class="content-wrapper">
-            <h1 class="white-text">Loading...</h1>
-        </div>
-        {% include vectors/preloader-mask.svg %}
-    </div>
+    {% include preloader-screen.html %}
     <div class="container">
         <div class="row main-content">
             <div class="column-md-6 main-content__side-photo">

--- a/_includes/preloader-screen.html
+++ b/_includes/preloader-screen.html
@@ -1,0 +1,13 @@
+<div class="preloader">
+    <noscript>
+        <!-- This ensures that user's with javascript turned off aren't incapacitated by our preloader -->
+        <style>
+            .preloader { display: none; }
+            body:not([data-preloader-displayed=true]) { overflow: initial; }
+        </style>
+    </noscript>
+    <div class="content-wrapper">
+        <h1 class="white-text">Loading...</h1>
+    </div>
+    {% include vectors/preloader-mask.svg %}
+</div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -2,7 +2,7 @@
 layout: default
 ---
 
-<body class="no-scroll">
+<body class="no-scroll" data-preloader-displayed="false">
 {%include landing.html%}
 {%include scripts.html%}
 </body>

--- a/assets/js/bundle.js
+++ b/assets/js/bundle.js
@@ -12,11 +12,12 @@
         const [, value] = cookieString.match(searchRegex);
 
         return value;
-    }
+    };
     
     document.addEventListener('DOMContentLoaded', function () {
         const ANIMATION_DURATION = 2000;
         const HAS_SEEN_PRELOADER_COOKIE = 'eoe_has_seen_preloader';
+        const HTML_PRELOADER_ATTRIBUTE = 'data-preloader-displayed';
 
         const DOM = {};
         DOM.preloader = global.document.querySelector('.preloader');
@@ -38,15 +39,17 @@
                 d: DOM.path.getAttribute('pathdata:id'),
                 complete: () => {
                     global.document.body.style.overflow = 'auto';
+                    global.document.body.setAttribute(HTML_PRELOADER_ATTRIBUTE, String(true));
                     // mark preloader as seen for the session
                     setCookie(HAS_SEEN_PRELOADER_COOKIE, true);
                 }
             });
-        }
+        };
 
         if(getCookieValue(HAS_SEEN_PRELOADER_COOKIE) === 'true') {
             DOM.preloader.style.display = 'none';
             global.document.body.style.overflow = 'auto';
+            global.document.body.setAttribute(HTML_PRELOADER_ATTRIBUTE, String(true));
         } else {
             setTimeout(() => removePreloader(ANIMATION_DURATION), 1000);
         }


### PR DESCRIPTION
- use `noscript` element to ensure users with javascript turned on still get to see website content